### PR TITLE
OP-1013: Disabling past dates in DatePicker

### DIFF
--- a/src/components/ProductForm/MainPanelForm.js
+++ b/src/components/ProductForm/MainPanelForm.js
@@ -125,7 +125,8 @@ const MainPanelForm = (props) => {
           required
           module="product"
           label="dateFrom"
-          readOnly={readOnly}
+          disablePast={!Boolean(edited?.uuid)}
+          readOnly={Boolean(edited?.uuid) || readOnly}
           onChange={(dateFrom) => onEditedChanged({ ...edited, dateFrom })}
         />
       </Grid>


### PR DESCRIPTION
Part of [CORE PR](https://github.com/openimis/openimis-fe-core_js/pull/89)

[OP-1013](https://openimis.atlassian.net/browse/OP-1013)

In scope of this ticket, I fixed _dateFrom_ field.
- If I create a new product, I can not schedule _dateFrom_ in the past.
- If I edit a given product, I can not change _dateFrom_.