### PR TITLE
OTC-881: Validation of product code

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1,0 +1,56 @@
+import { graphqlWithVariables } from "@openimis/fe-core";
+
+export const productCodeValidationCheck = (mm, variables) => {
+  return graphqlWithVariables(
+    `
+      query ($productCode: String!) {
+        isValid: validateProductCode(productCode: $productCode)
+      }
+      `,
+    variables,
+    `PRODUCT_CODE_FIELDS_VALIDATION`,
+  );
+};
+
+export const productCodeSetValid = () => {
+  return (dispatch) => {
+    dispatch({ type: `PRODUCT_CODE_SET_VALID` });
+  };
+};
+
+export const productCodeValidationClear = () => {
+  return (dispatch) => {
+    dispatch({
+      type: `PRODUCT_CODE_FIELDS_VALIDATION_CLEAR`,
+    });
+  };
+};
+
+export const fetchProduct = (mm, variables) => {
+  return graphqlWithVariables(
+    `
+    query ($productId: ID) {
+        product: products(id: $productId) {
+          edges {
+            node {
+              id
+              uuid
+              code
+              name
+            }
+          }
+        }
+      }
+        `,
+    variables,
+    `PRODUCT_FETCH_PRODUCT`,
+  );
+};
+
+export const clearProduct = () => {
+  return (dispatch) => {
+    dispatch({
+      type: `PRODUCT_FETCH_PRODUCT_CLEAR`,
+    });
+  };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import messages_en from "./translations/en.json";
 import ProductPicker from "./pickers/ProductPicker";
+import { reducer } from "./reducer";
 
 import ProductsPage from "./pages/ProductsPage";
 import ProductDetailsPage from "./pages/ProductDetailsPage";
@@ -7,11 +8,13 @@ import {
   GRAPHQL_USE_PRODUCTS_PRODUCT_FRAGMENT,
   GRAPHQL_USE_PRODUCT_PRODUCT_FRAGMENT,
   useProductsQuery,
-  useProductQuery, usePageDisplayRulesQuery,
+  useProductQuery,
+  usePageDisplayRulesQuery,
 } from "./hooks";
 
 const DEFAULT_CONFIG = {
   "translations": [{ key: "en", messages: messages_en }],
+  "reducers": [{ key: "product", reducer }],
   "core.Router": [
     { path: "admin/products", component: ProductsPage },
     { path: "admin/products/new", component: ProductDetailsPage },

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,0 +1,106 @@
+import { formatServerError, formatGraphQLError, parseData } from "@openimis/fe-core";
+
+const initialState = {
+  fetchingProduct: false,
+  product: {},
+  fetchedProduct: false,
+  errorProduct: null,
+  validationFields: null,
+};
+
+export const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    case "PRODUCT_FETCH_PRODUCT_REQ":
+      return {
+        ...state,
+        fetchingProduct: true,
+        product: {},
+        fetchedProduct: false,
+        errorProduct: null,
+      };
+    case "PRODUCT_FETCH_PRODUCT_RESP":
+      return {
+        ...state,
+        fetchingProduct: false,
+        product: parseData(action.payload.data?.product)?.[0],
+        fetchedProduct: true,
+        errorProduct: null,
+      };
+    case "PRODUCT_FETCH_PRODUCT_ERR":
+      return {
+        ...state,
+        fetchingProduct: false,
+        errorProduct: formatServerError(action.payload),
+      };
+    case "PRODUCT_FETCH_PRODUCT_CLEAR":
+      return {
+        ...state,
+        fetchingProduct: false,
+        product: {},
+        fetchedProduct: false,
+        errorProduct: null,
+      };
+    case "PRODUCT_CODE_FIELDS_VALIDATION_REQ":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          productCode: {
+            isValidating: true,
+            isValid: false,
+            validationError: null,
+          },
+        },
+      };
+    case "PRODUCT_CODE_FIELDS_VALIDATION_RESP":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          productCode: {
+            isValidating: false,
+            isValid: action.payload?.data.isValid,
+            validationError: formatGraphQLError(action.payload),
+          },
+        },
+      };
+    case "PRODUCT_CODE_FIELDS_VALIDATION_ERR":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          productCode: {
+            isValidating: false,
+            isValid: false,
+            validationError: formatServerError(action.payload),
+          },
+        },
+      };
+    case "PRODUCT_CODE_FIELDS_VALIDATION_CLEAR":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          productCode: {
+            isValidating: true,
+            isValid: false,
+            validationError: null,
+          },
+        },
+      };
+    case "PRODUCT_CODE_SET_VALID":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          productCode: {
+            isValidating: false,
+            isValid: true,
+            validationError: null,
+          },
+        },
+      };
+    default:
+      return state;
+  }
+};

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -43,6 +43,7 @@
   "product.insurancePeriod": "Insurance Period (months)",
   "product.administrationPeriod": "Administration Period (months)",
   "product.district": "District",
+  "product.alreadyTaken": "Product code already in use",
   "product.ProductFilters.showHistory": "Show Historical Values",
   "product.ProductSearcher.tableTitle": "{count} Products",
   "product.ProductSearcher.deleteProductTooltip": "Delete product",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 import { graphqlWithVariables, toISODate } from "@openimis/fe-core";
 import _ from "lodash";
 
-export const validateProductForm = (values, rules) => {
+export const validateProductForm = (values, rules, isProductCodeValid) => {
   values = { ...values };
 
   delete values.validityTo;
@@ -39,6 +39,10 @@ export const validateProductForm = (values, rules) => {
   if (values.dateFrom > values.dateTo) {
     errors.dateFrom = true;
     errors.dateTo = true;
+  }
+
+  if (!isProductCodeValid) {
+    errors.isProductCodeInvalid = true;
   }
 
   if (Object.keys(errors).length > 0) {


### PR DESCRIPTION
[OTC-881](https://openimis.atlassian.net/browse/OTC-881)

In scope of this ticket, I implemented validation of the product code.
- The Redux was missing in this module, so I had to create a reducer and related actions. 
- According to the previous validations, I blocked the possbility to save the form when product code is invalid.
- I fixed _isValid_ state when editing for the first time. This allows to save a form without any action taken (I had to interact with form before to unlock the possibility to save).
- I unlocked the possibility to change the product code during an edit (it was disabled before).
- I added new translation to Lokalise.

Related [BE](https://github.com/openimis/openimis-be-product_py/pull/26).


[OTC-881]: https://openimis.atlassian.net/browse/OTC-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ