### PR TITLE
OTC-967: Optional chaining to avoid form crash

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -73,7 +73,7 @@ export const getPriceOrigin= (priceOrigin) => {
 }
 
 export const validateItemOrService = (itemOrService, field, rules) => {
-  if (!/^\d+(?:\.\d{0,2})?$/.test(itemOrService[field].toString())) return false //check if up to two decimal points
+  if (!/^\d+(?:\.\d{0,2})?$/.test(itemOrService[field]?.toString())) return false //check if up to two decimal points
   return !(itemOrService[field] < rules.minLimitValue && itemOrService[field] > rules.maxLimitValue);
 }
 


### PR DESCRIPTION
[OTC-967](https://openimis.atlassian.net/browse/OTC-967)

Changes:
- Addition of optional chaining. Without this, the form was crashing when user tries to enter medical items/services.

[OTC-967]: https://openimis.atlassian.net/browse/OTC-967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ