### PR TITLE
OTC-938: fix displaying of N/A

### DIFF
--- a/src/components/ProductForm/DeductiblesCeilingsTabForm.js
+++ b/src/components/ProductForm/DeductiblesCeilingsTabForm.js
@@ -39,35 +39,24 @@ const DeductiblesCeilingsTabForm = (props) => {
     const isChecked = event.target.checked;
     onEditedChanged({
       ...edited,
-      deductible: "",
-      deductibleIp: "",
-      deductibleOp: "",
-      ceilingIp: "N/A",
-      ceilingOp: "N/A",
-      ceiling: "N/A",
-      maxPolicyExtraMemberIp: "N/A",
-      maxPolicyExtraMemberOp: "N/A",
-      maxPolicyExtraMember: "N/A",
-      maxCeilingPolicyIp: "N/A",
-      maxCeilingPolicyOp: "N/A",
-      maxCeilingPolicy: "N/A",
+      deductible: 0,
+      deductibleIp: 0,
+      deductibleOp: 0,
+      ceilingIp: undefined,
+      ceilingOp: undefined,
+      ceiling: undefined,
+      maxPolicyExtraMemberIp: undefined,
+      maxPolicyExtraMemberOp: undefined,
+      maxPolicyExtraMember: undefined,
+      maxCeilingPolicyIp: undefined,
+      maxCeilingPolicyOp: undefined,
+      maxCeilingPolicy: undefined,
     });
     _setSplit(isChecked);
   };
 
   const handleInputChange = (fieldName) => (value) => {
-    if (value === 0 && (fieldName.toLowerCase().includes("ceiling") || fieldName.includes("maxPolicyExtraMember") || fieldName.includes("maxAmount"))) {
-      value = "0"
-    }
     onEditedChanged({ ...edited, [fieldName]: value });
-  };
-
-  const handleCeilingBlur = (fieldName, event) => {
-    let value = event.target.value;
-    if (isNaN(value) || value === "") {
-      value = null
-      onEditedChanged({ ...edited, [fieldName]: value });
-    }
   };
 
   useEffect(() => {
@@ -139,7 +128,7 @@ const DeductiblesCeilingsTabForm = (props) => {
                       min={0}
                       module="product"
                       readOnly={readOnly}
-                      value={Number(edited.deductibleIp) !== 0 ? edited.deductibleIp : ""}
+                      value={edited?.deductibleIp ?? 0}
                       onChange={handleInputChange("deductibleIp")}
                     />
                   </TableCell>
@@ -148,7 +137,7 @@ const DeductiblesCeilingsTabForm = (props) => {
                       min={0}
                       module="product"
                       readOnly={readOnly}
-                      value={Number(edited.deductibleOp) !== 0 ? edited.deductibleOp : ""}
+                      value={edited?.deductibleOp ?? 0}
                       onChange={handleInputChange("deductibleOp")}
                     />
                   </TableCell>
@@ -159,7 +148,7 @@ const DeductiblesCeilingsTabForm = (props) => {
                     min={0}
                     module="product"
                     readOnly={readOnly}
-                    value={Number(edited.deductible) !== 0 ? edited.deductible : ""}
+                    value={edited?.deductible ?? 0}
                     onChange={handleInputChange("deductible")}
                   />
                 </TableCell>
@@ -195,9 +184,11 @@ const DeductiblesCeilingsTabForm = (props) => {
                       min={0}
                       module="product"
                       readOnly={readOnly}
-                      value={edited?.ceilingIp ?? "N/A"}
+                      value={edited?.ceilingIp}
                       onChange={handleInputChange("ceilingIp")}
                       onBlur={(event) => handleCeilingBlur("ceilingIp", event)}
+                      displayNa
+                      displayZero
                     />
                   </TableCell>
                   <TableCell>
@@ -205,9 +196,11 @@ const DeductiblesCeilingsTabForm = (props) => {
                       min={0}
                       module="product"
                       readOnly={readOnly}
-                      value={edited?.ceilingOp ?? "N/A"}
+                      value={edited?.ceilingOp}
                       onChange={handleInputChange("ceilingOp")}
                       onBlur={(event) => handleCeilingBlur("ceilingOp", event)}
+                      displayNa
+                      displayZero
                     />
                   </TableCell>
                 </>
@@ -217,9 +210,11 @@ const DeductiblesCeilingsTabForm = (props) => {
                     min={0}
                     module="product"
                     readOnly={readOnly}
-                    value={edited?.ceiling ?? "N/A"}
+                    value={edited?.ceiling}
                     onChange={handleInputChange("ceiling")}
                     onBlur={(event) => handleCeilingBlur("ceiling", event)}
+                    displayNa
+                    displayZero
                   />
                 </TableCell>
               )}
@@ -235,9 +230,11 @@ const DeductiblesCeilingsTabForm = (props) => {
                       min={0}
                       module="product"
                       readOnly={readOnly}
-                      value={edited?.maxPolicyExtraMemberIp ?? "N/A"}
+                      value={edited?.maxPolicyExtraMemberIp}
                       onChange={handleInputChange("maxPolicyExtraMemberIp")}
                       onBlur={(event) => handleCeilingBlur("maxPolicyExtraMemberIp", event)}
+                      displayNa
+                      displayZero
                     />
                   </TableCell>
                   <TableCell>
@@ -245,9 +242,11 @@ const DeductiblesCeilingsTabForm = (props) => {
                       min={0}
                       module="product"
                       readOnly={readOnly}
-                      value={edited?.maxPolicyExtraMemberOp ?? "N/A"}
+                      value={edited?.maxPolicyExtraMemberOp}
                       onChange={handleInputChange("maxPolicyExtraMemberOp")}
                       onBlur={(event) => handleCeilingBlur("maxPolicyExtraMemberOp", event)}
+                      displayNa
+                      displayZero
                     />
                   </TableCell>
                 </>
@@ -257,9 +256,11 @@ const DeductiblesCeilingsTabForm = (props) => {
                     min={0}
                     module="product"
                     readOnly={readOnly}
-                    value={edited?.maxPolicyExtraMember ?? "N/A"}
+                    value={edited?.maxPolicyExtraMember}
                     onChange={handleInputChange("maxPolicyExtraMember")}
                     onBlur={(event) => handleCeilingBlur("maxPolicyExtraMember", event)}
+                    displayNa
+                    displayZero
                   />
                 </TableCell>
               )}
@@ -275,9 +276,11 @@ const DeductiblesCeilingsTabForm = (props) => {
                       min={0}
                       module="product"
                       readOnly={readOnly}
-                      value={edited?.maxCeilingPolicyIp ?? "N/A"}
+                      value={edited?.maxCeilingPolicyIp}
                       onChange={handleInputChange("maxCeilingPolicyIp")}
                       onBlur={(event) => handleCeilingBlur("maxCeilingPolicyIp", event)}
+                      displayNa
+                      displayZero
                     />
                   </TableCell>
                   <TableCell>
@@ -285,9 +288,11 @@ const DeductiblesCeilingsTabForm = (props) => {
                       min={0}
                       module="product"
                       readOnly={readOnly}
-                      value={edited?.maxCeilingPolicyOp ?? "N/A"}
+                      value={edited?.maxCeilingPolicyOp}
                       onChange={handleInputChange("maxCeilingPolicyOp")}
                       onBlur={(event) => handleCeilingBlur("maxCeilingPolicyOp", event)}
+                      displayNa
+                      displayZero
                     />
                   </TableCell>
                 </>
@@ -297,9 +302,11 @@ const DeductiblesCeilingsTabForm = (props) => {
                     min={0}
                     module="product"
                     readOnly={readOnly}
-                    value={edited?.maxCeilingPolicy ?? "N/A"}
+                    value={edited?.maxCeilingPolicy}
                     onChange={handleInputChange("maxCeilingPolicy")}
                     onBlur={(event) => handleCeilingBlur("maxCeilingPolicy", event)}
+                    displayNa
+                    displayZero
                   />
                 </TableCell>
               )}
@@ -326,7 +333,7 @@ const DeductiblesCeilingsTabForm = (props) => {
                   min={0}
                   module="product"
                   readOnly={readOnly}
-                  value={edited.maxNoConsultation}
+                  value={edited?.maxNoConsultation ?? 0}
                   onChange={handleInputChange("maxNoConsultation")}
                 />
               </TableCell>
@@ -335,9 +342,11 @@ const DeductiblesCeilingsTabForm = (props) => {
                   min={0}
                   module="product"
                   readOnly={readOnly}
-                  value={edited?.maxAmountConsultation ?? "N/A"}
+                  value={edited?.maxAmountConsultation}
                   onChange={handleInputChange("maxAmountConsultation")}
                   onBlur={(event) => handleCeilingBlur("maxAmountConsultation", event)}
+                  displayNa
+                  displayZero
                 />
               </TableCell>
             </TableRow>
@@ -350,7 +359,7 @@ const DeductiblesCeilingsTabForm = (props) => {
                   min={0}
                   module="product"
                   readOnly={readOnly}
-                  value={edited.maxNoSurgery}
+                  value={edited?.maxNoSurgery ?? 0}
                   onChange={handleInputChange("maxNoSurgery")}
                 />
               </TableCell>
@@ -359,9 +368,11 @@ const DeductiblesCeilingsTabForm = (props) => {
                   min={0}
                   module="product"
                   readOnly={readOnly}
-                  value={edited?.maxAmountSurgery ?? "N/A"}
+                  value={edited?.maxAmountSurgery}
                   onChange={handleInputChange("maxAmountSurgery")}
                   onBlur={(event) => handleCeilingBlur("maxAmountSurgery", event)}
+                  displayNa
+                  displayZero
                 />
               </TableCell>
             </TableRow>
@@ -374,7 +385,7 @@ const DeductiblesCeilingsTabForm = (props) => {
                   min={0}
                   module="product"
                   readOnly={readOnly}
-                  value={edited.maxNoDelivery}
+                  value={edited?.maxNoDelivery ?? 0}
                   onChange={handleInputChange("maxNoDelivery")}
                 />
               </TableCell>
@@ -383,9 +394,11 @@ const DeductiblesCeilingsTabForm = (props) => {
                   min={0}
                   module="product"
                   readOnly={readOnly}
-                  value={edited?.maxAmountDelivery ?? "N/A"}
+                  value={edited?.maxAmountDelivery}
                   onChange={handleInputChange("maxAmountDelivery")}
                   onBlur={(event) => handleCeilingBlur("maxAmountDelivery", event)}
+                  displayNa
+                  displayZero
                 />
               </TableCell>
             </TableRow>
@@ -398,7 +411,7 @@ const DeductiblesCeilingsTabForm = (props) => {
                   min={0}
                   module="product"
                   readOnly={readOnly}
-                  value={edited.maxNoHospitalization}
+                  value={edited?.maxNoHospitalization ?? 0}
                   onChange={handleInputChange("maxNoHospitalization")}
                 />
               </TableCell>
@@ -407,9 +420,11 @@ const DeductiblesCeilingsTabForm = (props) => {
                   min={0}
                   module="product"
                   readOnly={readOnly}
-                  value={edited?.maxAmountHospitalization ?? "N/A"}
+                  value={edited?.maxAmountHospitalization}
                   onChange={handleInputChange("maxAmountHospitalization")}
                   onBlur={(event) => handleCeilingBlur("maxAmountHospitalization", event)}
+                  displayNa
+                  displayZero
                 />
               </TableCell>
             </TableRow>
@@ -422,7 +437,7 @@ const DeductiblesCeilingsTabForm = (props) => {
                   min={0}
                   module="product"
                   readOnly={readOnly}
-                  value={edited.maxNoAntenatal}
+                  value={edited?.maxNoAntenatal ?? 0}
                   onChange={handleInputChange("maxNoAntenatal")}
                 />
               </TableCell>
@@ -431,9 +446,11 @@ const DeductiblesCeilingsTabForm = (props) => {
                   min={0}
                   module="product"
                   readOnly={readOnly}
-                  value={edited?.maxAmountAntenatal ?? "N/A"}
+                  value={edited?.maxAmountAntenatal}
                   onChange={handleInputChange("maxAmountAntenatal")}
                   onBlur={(event) => handleCeilingBlur("maxAmountAntenatal", event)}
+                  displayNa
+                  displayZero
                 />
               </TableCell>
             </TableRow>

--- a/src/components/ProductForm/MainPanelForm.js
+++ b/src/components/ProductForm/MainPanelForm.js
@@ -53,8 +53,6 @@ const MainPanelForm = (props) => {
     return true;
   };
 
-  console.log(edited, edited?.threshold)
-
   return (
     <Grid container direction="row">
       <Grid item xs={3} className={classes.item}>

--- a/src/components/ProductForm/MainPanelForm.js
+++ b/src/components/ProductForm/MainPanelForm.js
@@ -53,6 +53,8 @@ const MainPanelForm = (props) => {
     return true;
   };
 
+  console.log(edited, edited?.threshold)
+
   return (
     <Grid container direction="row">
       <Grid item xs={3} className={classes.item}>


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OTC-938

This PR fixes displaying N/A's. The value is ready to be displayed using translations. 

This PR is also a part of: https://github.com/openimis/openimis-fe-core_js/pull/103