### PR TITLE
OTC-1037: renderInput added - product picker label fixed

### DIFF
--- a/src/pickers/ProductPicker.js
+++ b/src/pickers/ProductPicker.js
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
+import { TextField } from "@material-ui/core";
 import { Autocomplete, useModulesManager, useTranslations } from "@openimis/fe-core";
 import { useProductsQuery } from "../hooks";
 
@@ -6,10 +7,11 @@ const ProductPicker = (props) => {
   const {
     multiple,
     required,
-    placeholder,
     label,
-    withLabel,
-    withPlaceholder,
+    nullLabel,
+    withLabel = false,
+    placeholder,
+    withPlaceholder = false,
     readOnly,
     value,
     onChange,
@@ -30,12 +32,7 @@ const ProductPicker = (props) => {
   return (
     <Autocomplete
       multiple={multiple}
-      required={required}
       error={error}
-      placeholder={placeholder ?? formatMessage("ProductPicker.placeholder")}
-      label={label ?? formatMessage("Product")}
-      withLabel={withLabel}
-      withPlaceholder={withPlaceholder}
       readOnly={readOnly}
       options={data.products ?? []}
       isLoading={isLoading}
@@ -46,6 +43,14 @@ const ProductPicker = (props) => {
       filterOptions={filter}
       filterSelectedOptions={filterSelectedOptions}
       onInputChange={(search) => setFilters({ first: 15, search, location: locationId })}
+      renderInput={(inputProps) => (
+        <TextField
+          {...inputProps}
+          required={required}
+          label={withLabel && (label || nullLabel)}
+          placeholder={withPlaceholder && (placeholder || formatMessage("Search..."))}
+        />
+      )}
     />
   );
 };


### PR DESCRIPTION
[OTC-1037](https://openimis.atlassian.net/browse/OTC-1037)

**[CORE PR](https://github.com/openimis/openimis-fe-core_js/pull/110) AND [POLICY PR](https://github.com/openimis/openimis-fe-policy_js/pull/42) REQUIRED**

Changes:
- I added the _renderInput_ prop to the ProductPicker to fix the issue with crashing label and placeholder.

[OTC-1037]: https://openimis.atlassian.net/browse/OTC-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ