### PR TITLE
OP-1532: adjust data grid to handle changes properly

### DIFF
--- a/src/components/ProductForm/GenericItemsTabForm.js
+++ b/src/components/ProductForm/GenericItemsTabForm.js
@@ -34,7 +34,7 @@ const ItemsTabForm = (props) => {
   const [MIN_VALUE, setMinValue] = useState(0);
   const [MAX_VALUE, setMaxValue] = useState(100);
 
-  const parserLimits= (value,) => {
+  const parserLimits = (value,) => {
     value = Number(value)
     if (value > MAX_VALUE) value = MIN_VALUE
     else if (value < MIN_VALUE) value = MAX_VALUE
@@ -123,8 +123,9 @@ const ItemsTabForm = (props) => {
         editable: true,
         disableColumnMenu: true,
         sortable: false,
-        valueParser: (value) => {
-          if (value < 0) return null;
+        valueParser: (value) => value,
+        valueGetter: ({ value }) => {
+          if (typeof value === 'number') return value.toString();
           return value;
         },
       })),

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,6 +3,7 @@ export const RIGHT_PRODUCT_DELETE = 121004;
 export const RIGHT_PRODUCT_ADD = 121002;
 export const RIGHT_PRODUCT_UPDATE = 121003;
 export const RIGHT_PRODUCT_DUPLICATE = 121005;
+export const EMPTY_STRING = '';
 
 export const PRODUCT_QUANTITY_LIMIT = 15;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 import { graphqlWithVariables, toISODate } from "@openimis/fe-core";
 import _ from "lodash";
-import { LIMIT_COLUMNS, LIMIT_TYPES, PRICE_ORIGINS } from "./constants";
+import { EMPTY_STRING, LIMIT_COLUMNS, LIMIT_TYPES, PRICE_ORIGINS } from "./constants";
 
 export const validateProductForm = (values, rules, isProductCodeValid) => {
   values = { ...values };
@@ -120,15 +120,43 @@ export const toInputValues = (values) => {
     ...inputValues
   } = values;
 
-  const formatService = ({ service, id, ...params }) => ({
-    serviceUuid: service.uuid,
-    ...params,
-  });
+  const formatService = ({ service, id, ...params }) => {
+    const {
+      limitNoAdult,
+      limitNoChild,
+      waitingPeriodAdult,
+      waitingPeriodChild,
+      ...restParams
+    } = params;
 
-  const formatItem = ({ item, id, ...params }) => ({
-    itemUuid: item.uuid,
-    ...params,
-  });
+    return {
+      serviceUuid: service.uuid,
+      limitNoAdult: limitNoAdult === EMPTY_STRING ? null : parseInt(limitNoAdult),
+      limitNoChild: limitNoChild === EMPTY_STRING ? null : parseInt(limitNoChild),
+      waitingPeriodAdult: waitingPeriodAdult === EMPTY_STRING ? null : parseInt(waitingPeriodAdult),
+      waitingPeriodChild: waitingPeriodChild === EMPTY_STRING ? null : parseInt(waitingPeriodChild),
+      ...restParams,
+    }
+  };
+
+  const formatItem = ({ item, id, ...params }) => {
+    const {
+      limitNoAdult,
+      limitNoChild,
+      waitingPeriodAdult,
+      waitingPeriodChild,
+      ...restParams
+    } = params;
+
+    return {
+      itemUuid: item.uuid,
+      limitNoAdult: limitNoAdult === EMPTY_STRING ? null : parseInt(limitNoAdult),
+      limitNoChild: limitNoChild === EMPTY_STRING ? null : parseInt(limitNoChild),
+      waitingPeriodAdult: waitingPeriodAdult === EMPTY_STRING ? null : parseInt(waitingPeriodAdult),
+      waitingPeriodChild: waitingPeriodChild === EMPTY_STRING ? null : parseInt(waitingPeriodChild),
+      ...restParams,
+    }
+  };
 
   const val = {
     ...inputValues,


### PR DESCRIPTION
[OP-1532](https://openimis.atlassian.net/browse/OP-1532)

Changes:
- Properly manage changes to the fields: "limitNoAdult," "limitNoChild," "waitingPeriodAdult," and "waitingPeriodChild."

Rules:
- When a cell is left blank by the user, interpret it as indicating the absence of a limit.
- If the user enters '0' in a cell, understand this as specifying a limit of 0.
- Any other user-entered value should be taken as the designated limit.

Demo:
![datagrid](https://github.com/openimis/openimis-fe-product_js/assets/109145288/291e52e5-3fa7-4345-87fa-b1d92a5c66ad)
