### PR TITLE
OMT-331 - Product Derived Operational Indicators report

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,22 +43,13 @@ const DEFAULT_CONFIG = {
     {
       key: "product_derived_operational_indicators",
       component: ProductDerivedOperationalIndicators,
-      isValid: (values) => values.year && values.region,
+      isValid: (values) => values.year && values.product,
       getParams: (values) => {
         const params = {}
-        if (values.district) {
-          params.requested_district_id = decodeId(values.district.id);
-        }
-        if (values.product) {
-          params.requested_product_id = decodeId(values.product.id);
-        }
-        if (values.hf) {
-          params.requested_hf_id = decodeId(values.hf.id);
-        }
         if (values.month) {
           params.requested_month = values.month;
         }
-        params.requested_region_id = decodeId(values.region.id);
+        params.requested_product_id = decodeId(values.product.id);
         params.requested_year = values.year;
         return params;
       },

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import {
   usePageDisplayRulesQuery,
 } from "./hooks";
 import ProductSalesReport from "./reports/ProductSalesReport";
+import ProductDerivedOperationalIndicators from "./reports/ProductDerivedOperationalIndicators";
 
 const DEFAULT_CONFIG = {
   "translations": [{ key: "en", messages: messages_en }],
@@ -36,6 +37,29 @@ const DEFAULT_CONFIG = {
         }
         params.date_start = values.dateFrom;
         params.date_end = values.dateTo;
+        return params;
+      },
+    },
+    {
+      key: "product_derived_operational_indicators",
+      component: ProductDerivedOperationalIndicators,
+      isValid: (values) => values.year && values.region,
+      getParams: (values) => {
+        const params = {}
+        if (values.district) {
+          params.requested_district_id = decodeId(values.district.id);
+        }
+        if (values.product) {
+          params.requested_product_id = decodeId(values.product.id);
+        }
+        if (values.hf) {
+          params.requested_hf_id = decodeId(values.hf.id);
+        }
+        if (values.month) {
+          params.requested_month = values.month;
+        }
+        params.requested_region_id = decodeId(values.region.id);
+        params.requested_year = values.year;
         return params;
       },
     },

--- a/src/reports/ProductDerivedOperationalIndicators.js
+++ b/src/reports/ProductDerivedOperationalIndicators.js
@@ -1,0 +1,92 @@
+import { Grid } from "@material-ui/core";
+import { PublishedComponent, useModulesManager, useTranslations } from "@openimis/fe-core";
+import React from "react";
+
+const ProductDerivedOperationalIndicators = (props) => {
+  const { values, setValues } = props;
+  const modulesManager = useModulesManager();
+  const { formatMessage } = useTranslations("product", modulesManager);
+
+  return (
+    <Grid container direction="column" spacing={1}>
+      <Grid item>
+        <PublishedComponent
+          pubRef="core.YearPicker"
+          onChange={(year) =>
+            setValues({
+                ...values,
+                year,
+          })}
+          min={2010}
+          max={2040}
+          required
+          withNull={false}
+          value={values.year}
+          label={formatMessage("ProductDerivedOperationalIndicators.year")}
+        />
+      </Grid>
+      <Grid item>
+        <PublishedComponent
+          pubRef="location.LocationPicker"
+          onChange={(region) =>
+            setValues({
+                ...values,
+                region,
+                district:null
+          })}
+          required
+          value={values.region}
+          locationLevel={0}
+          label={formatMessage("ProductDerivedOperationalIndicators.region")}
+        />
+      </Grid>
+      <Grid item>
+        <PublishedComponent
+          pubRef="location.LocationPicker"
+          onChange={(district) =>
+            setValues({
+                ...values,
+                district,
+          })}
+          value={values.district}
+          parentLocation={values.region}
+          locationLevel={1}
+          label={formatMessage("ProductDerivedOperationalIndicators.district")}
+        />
+      </Grid>
+      <Grid item>
+        <PublishedComponent
+          pubRef="product.ProductPicker"
+          onChange={(product) => setValues({ ...values, product })}
+          module="product"
+          value={values.product}
+          label={formatMessage("ProductDerivedOperationalIndicators.product")}
+        />
+      </Grid>
+      <Grid item>
+        <PublishedComponent
+          pubRef="location.HealthFacilityPicker"
+          onChange={(hf) => setValues({ ...values, hf, })}
+          region={values.region}
+          district={values.district}
+          value={values.hf}
+          label={formatMessage("ProductDerivedOperationalIndicators.hf")}
+        />
+      </Grid>
+      <Grid item>
+        <PublishedComponent
+          pubRef="core.MonthPicker"
+          onChange={(month) =>
+            setValues({
+                ...values,
+                month,
+          })}
+          withNull
+          value={values.month}
+        />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default ProductDerivedOperationalIndicators;

--- a/src/reports/ProductDerivedOperationalIndicators.js
+++ b/src/reports/ProductDerivedOperationalIndicators.js
@@ -11,6 +11,16 @@ const ProductDerivedOperationalIndicators = (props) => {
     <Grid container direction="column" spacing={1}>
       <Grid item>
         <PublishedComponent
+          pubRef="product.ProductPicker"
+          onChange={(product) => setValues({ ...values, product })}
+          module="product"
+          required
+          value={values.product}
+          label={formatMessage("ProductDerivedOperationalIndicators.product")}
+        />
+      </Grid>
+      <Grid item>
+        <PublishedComponent
           pubRef="core.YearPicker"
           onChange={(year) =>
             setValues({
@@ -23,54 +33,6 @@ const ProductDerivedOperationalIndicators = (props) => {
           withNull={false}
           value={values.year}
           label={formatMessage("ProductDerivedOperationalIndicators.year")}
-        />
-      </Grid>
-      <Grid item>
-        <PublishedComponent
-          pubRef="location.LocationPicker"
-          onChange={(region) =>
-            setValues({
-                ...values,
-                region,
-                district:null
-          })}
-          required
-          value={values.region}
-          locationLevel={0}
-          label={formatMessage("ProductDerivedOperationalIndicators.region")}
-        />
-      </Grid>
-      <Grid item>
-        <PublishedComponent
-          pubRef="location.LocationPicker"
-          onChange={(district) =>
-            setValues({
-                ...values,
-                district,
-          })}
-          value={values.district}
-          parentLocation={values.region}
-          locationLevel={1}
-          label={formatMessage("ProductDerivedOperationalIndicators.district")}
-        />
-      </Grid>
-      <Grid item>
-        <PublishedComponent
-          pubRef="product.ProductPicker"
-          onChange={(product) => setValues({ ...values, product })}
-          module="product"
-          value={values.product}
-          label={formatMessage("ProductDerivedOperationalIndicators.product")}
-        />
-      </Grid>
-      <Grid item>
-        <PublishedComponent
-          pubRef="location.HealthFacilityPicker"
-          onChange={(hf) => setValues({ ...values, hf, })}
-          region={values.region}
-          district={values.district}
-          value={values.hf}
-          label={formatMessage("ProductDerivedOperationalIndicators.hf")}
         />
       </Grid>
       <Grid item>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -178,8 +178,5 @@
   "product.ProductSalesReport.district": "District",
   "product.ProductDerivedOperationalIndicators.month": "Month",
   "product.ProductDerivedOperationalIndicators.year": "Year",
-  "product.ProductDerivedOperationalIndicators.region": "Region",
-  "product.ProductDerivedOperationalIndicators.district": "District",
-  "product.ProductDerivedOperationalIndicators.product": "Product",
-  "product.ProductDerivedOperationalIndicators.hf": "Health Facility"
+  "product.ProductDerivedOperationalIndicators.product": "Product"
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -175,5 +175,11 @@
   "product.ProductSalesReport.dateFrom": "From",
   "product.ProductSalesReport.dateTo": "To",
   "product.ProductSalesReport.region": "Region",
-  "product.ProductSalesReport.district": "District"
+  "product.ProductSalesReport.district": "District",
+  "product.ProductDerivedOperationalIndicators.month": "Month",
+  "product.ProductDerivedOperationalIndicators.year": "Year",
+  "product.ProductDerivedOperationalIndicators.region": "Region",
+  "product.ProductDerivedOperationalIndicators.district": "District",
+  "product.ProductDerivedOperationalIndicators.product": "Product",
+  "product.ProductDerivedOperationalIndicators.hf": "Health Facility"
 }


### PR DESCRIPTION
[Ticket](https://openimis.atlassian.net/browse/OMT-331)
[BE PR](https://github.com/openimis/openimis-be-product_py/pull/42)


:warning: There are a lot of differences between the documentation on readthedocs and the actual report (if you manage to generate one).
So, some decisions had to be made:
 - In the legacy version, 2 stored procedures were called uspSSRSDerivedIndicators1 and uspSSRSDerivedIndicators2. They handled data that looked similar but was different in many places. Merging the results of these two stored procedures does not make sense since the data was sorted and displayed on various fields including health facility - and this piece of data is not relevant for uspSSRSDerivedIndicators1.
 - This report is going to handle uspSSRSDerivedIndicators1 only. The other SP will be handled in another report.
 - There is no longer a Location parameter as the Location picker was mainly used to filter products. On top of that, as each Family can only have a Product available in their current Location, this Location is already known thanks to the Product. There is no need to search through the Family to get the district or region.
 - There are no longer overall ratios for the selected period as it is not clear how they were calculated (are `0` values for a given month included in the overall average? Sometimes it makes sense, sometimes it doesn't). The code handling the overall ratios will be commented out once the community decides on what to do here.