### PR TITLE
OP-1536: pass required prop to the autocomplete

### DIFF
--- a/src/pickers/ProductPicker.js
+++ b/src/pickers/ProductPicker.js
@@ -37,6 +37,7 @@ const ProductPicker = (props) => {
   return (
     <Autocomplete
       multiple={multiple}
+      required={required}
       error={error}
       readOnly={readOnly}
       options={products ?? []}


### PR DESCRIPTION
[OP-1536](https://openimis.atlassian.net/browse/OP-1536)

[RELATED CORE PR](https://github.com/openimis/openimis-fe-core_js/pull/153)

Changes:
- Pass required prop to the Autocomplete component.

[OP-1536]: https://openimis.atlassian.net/browse/OP-1536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ