### PR TITLE
OP-1645: count start date of a product

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -4,6 +4,7 @@ export const RIGHT_PRODUCT_ADD = 121002;
 export const RIGHT_PRODUCT_UPDATE = 121003;
 export const RIGHT_PRODUCT_DUPLICATE = 121005;
 export const EMPTY_STRING = '';
+export const DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 
 export const PRODUCT_QUANTITY_LIMIT = 15;
 

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -19,6 +19,11 @@ export const GRAPHQL_USE_PRODUCTS_PRODUCT_FRAGMENT = `
 
 export const useProductsQuery = ({ filters }, config) => {
   const modulesManager = useModulesManager();
+  // NOTE: The usage of `dateFrom_Lte: $dateFrom` and `dateTo_Gte: $dateTo` in the GraphQL query
+  // seems to imply a reserved naming convention. This might indicate a potential issue or limitation
+  // in the backend's handling of date range filters. The current solution is adjusted to align with 
+  // the backend's existing implementation. Further investigation or backend adjustments may be required
+  // for a more intuitive approach.
   const { isLoading, error, data, refetch } = useGraphqlQuery(
     `
   query (

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -27,7 +27,7 @@ export const useProductsQuery = ({ filters }, config) => {
     ) {
     products (
       search: $search, first: $first, last: $last, before: $before, after: $after, code_Icontains: $code, showHistory: $showHistory,
-      name_Icontains: $name, dateFrom_Gte: $dateFrom, dateTo_Lte: $dateTo, location: $location
+      name_Icontains: $name, dateFrom_Lte: $dateFrom, dateTo_Gte: $dateTo, location: $location
       ) {
       edges {
         node {

--- a/src/pickers/ProductPicker.js
+++ b/src/pickers/ProductPicker.js
@@ -59,6 +59,7 @@ const ProductPicker = (props) => {
           search,
           location: locationId,
           dateFrom: moment(enrollmentDate).format(DATE_FORMAT),
+          dateTo: moment(enrollmentDate).format(DATE_FORMAT),
         }))
       }
       renderInput={(inputProps) => (

--- a/src/pickers/ProductPicker.js
+++ b/src/pickers/ProductPicker.js
@@ -1,9 +1,10 @@
 import React, { useState } from "react";
+import moment from "moment";
 
 import { TextField, Tooltip } from "@material-ui/core";
 
 import { Autocomplete, useModulesManager, useTranslations } from "@openimis/fe-core";
-import { PRODUCT_QUANTITY_LIMIT } from "../constants";
+import { DATE_FORMAT, EMPTY_STRING, PRODUCT_QUANTITY_LIMIT } from "../constants";
 import { useProductsQuery } from "../hooks";
 
 const ProductPicker = (props) => {
@@ -21,11 +22,15 @@ const ProductPicker = (props) => {
     filter,
     filterSelectedOptions,
     locationId,
+    enrollmentDate,
   } = props;
 
   const modulesManager = useModulesManager();
-  const [filters, setFilters] = useState({ location: locationId });
-  const [currentString, setCurrentString] = useState("");
+  const [filters, setFilters] = useState({
+    location: locationId,
+    enrollmentDate: null,
+  });
+  const [currentString, setCurrentString] = useState(EMPTY_STRING);
   const { formatMessage, formatMessageWithValues } = useTranslations("product", modulesManager);
   const {
     isLoading,
@@ -48,13 +53,20 @@ const ProductPicker = (props) => {
       setCurrentString={setCurrentString}
       filterOptions={filter}
       filterSelectedOptions={filterSelectedOptions}
-      onInputChange={(search) => setFilters({ first: PRODUCT_QUANTITY_LIMIT, search, location: locationId })}
+      onInputChange={(search) =>
+        setFilters(() => ({
+          first: PRODUCT_QUANTITY_LIMIT,
+          search,
+          location: locationId,
+          dateFrom: moment(enrollmentDate).format(DATE_FORMAT),
+        }))
+      }
       renderInput={(inputProps) => (
         <Tooltip
           title={
             shouldShowTooltip
               ? formatMessageWithValues("ProductPicker.aboveLimit", { limit: PRODUCT_QUANTITY_LIMIT })
-              : ""
+              : EMPTY_STRING
           }
         >
           <TextField

--- a/src/pickers/ProductPicker.js
+++ b/src/pickers/ProductPicker.js
@@ -28,7 +28,6 @@ const ProductPicker = (props) => {
   const modulesManager = useModulesManager();
   const [filters, setFilters] = useState({
     location: locationId,
-    enrollmentDate: null,
   });
   const [currentString, setCurrentString] = useState(EMPTY_STRING);
   const { formatMessage, formatMessageWithValues } = useTranslations("product", modulesManager);


### PR DESCRIPTION
[OP-1645](https://openimis.atlassian.net/browse/OP-1645)

[REQUIRED PR](https://github.com/openimis/openimis-fe-policy_js/pull/71)

Changes:
- Access to the product is restricted if the enrollment date precedes the product's 'dateFrom'.

[OP-1645]: https://openimis.atlassian.net/browse/OP-1645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ