### PR TITLE
OP-1628: show action buttons if historical items displayed

### DIFF
--- a/src/components/ProductSearcher.js
+++ b/src/components/ProductSearcher.js
@@ -80,31 +80,29 @@ const ProductSearcher = (props) => {
       (p) => formatDateFromISO(p.dateFrom),
       (p) => formatDateFromISO(p.dateTo),
       (p) => p.maxMembers,
-
-      (p) =>
-        !filters.showHistory?.value ? (
-          <div className={classes.horizontalButtonContainer}>
-            <Tooltip title={formatMessage("ProductSearcher.openNewTab")}>
-              <IconButton onClick={() => onDoubleClick(p, true)}>
-                <TabIcon />
+      (p) => (
+        <div className={classes.horizontalButtonContainer}>
+          <Tooltip title={formatMessage("ProductSearcher.openNewTab")}>
+            <IconButton onClick={() => onDoubleClick(p, true)}>
+              <TabIcon />
+            </IconButton>
+          </Tooltip>
+          {canDuplicate(p) && (
+            <Tooltip title={formatMessage("ProductSearcher.duplicateProductTooltip")}>
+              <IconButton onClick={() => onDuplicate(p, true)}>
+                <FileCopyIcon />
               </IconButton>
             </Tooltip>
-            {canDuplicate(p) && (
-              <Tooltip title={formatMessage("ProductSearcher.duplicateProductTooltip")}>
-                <IconButton onClick={() => onDuplicate(p, true)}>
-                  <FileCopyIcon />
-                </IconButton>
-              </Tooltip>
-            )}
-            {canDelete(p) && (
-              <Tooltip title={formatMessage("ProductSearcher.deleteProductTooltip")}>
-                <IconButton onClick={() => setProductToDelete(p)}>
-                  <DeleteIcon />
-                </IconButton>
-              </Tooltip>
-            )}
-          </div>
-        ) : null,
+          )}
+          {canDelete(p) && (
+            <Tooltip title={formatMessage("ProductSearcher.deleteProductTooltip")}>
+              <IconButton onClick={() => setProductToDelete(p)}>
+                <DeleteIcon />
+              </IconButton>
+            </Tooltip>
+          )}
+        </div>
+      ),
     ];
   }, []);
   return (


### PR DESCRIPTION
[OP-1628](https://openimis.atlassian.net/browse/OP-1628)

Changes:
- Show action buttons when 'Show Historical Values' checked.
![image](https://github.com/openimis/openimis-fe-product_js/assets/109145288/411ed86f-73dd-498c-8349-2b2bd1338b9b)



[OP-1628]: https://openimis.atlassian.net/browse/OP-1628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ