### PR TITLE
OP-1631: not allowed to save when payment grace period empty

### DIFF
--- a/src/components/ProductForm/ContributionTabForm.js
+++ b/src/components/ProductForm/ContributionTabForm.js
@@ -174,8 +174,8 @@ const ContributionTabForm = (props) => {
           required
           label="gracePeriodPayment"
           readOnly={readOnly}
-          value={edited?.gracePeriodPayment ?? 0}
-          onChange={(gracePeriodPayment) => onEditedChanged({ ...edited, gracePeriodPayment: Number(gracePeriodPayment) })}
+          value={edited?.gracePeriodPayment}
+          onChange={(gracePeriodPayment) => onEditedChanged({ ...edited, gracePeriodPayment })}
           displayZero={true}
         />
       </Grid>


### PR DESCRIPTION
[OP-1631](https://openimis.atlassian.net/browse/OP-1631)

Changes:
- If payment grace period is empty, do not allow to save the product. It should allow value of 0, but if input is empty, saving should be blocked.

![Peek 2023-12-18 13-55](https://github.com/openimis/openimis-fe-product_js/assets/109145288/7346311e-3827-4026-b64d-f9a583543a31)


[OP-1631]: https://openimis.atlassian.net/browse/OP-1631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ