### PR TITLE
OP-1725: remove null/empty options from dropdown

### DIFF
--- a/src/components/ProductForm/MainPanelForm.js
+++ b/src/components/ProductForm/MainPanelForm.js
@@ -92,7 +92,7 @@ const MainPanelForm = (props) => {
           pubRef="location.RegionPicker"
           value={edited.location?.parent ?? edited.location}
           readOnly={readOnly}
-          withNull
+          withNull={false}
           onChange={(location) => onEditedChanged({ ...edited, location })}
         />
       </Grid>
@@ -101,7 +101,7 @@ const MainPanelForm = (props) => {
           region={edited.location?.parent || edited.location}
           value={edited.location?.parent ? edited.location : null}
           pubRef="location.DistrictPicker"
-          withNull={true}
+          withNull={false}
           readOnly={readOnly}
           onChange={(location) => onEditedChanged({ ...edited, location: location || edited.location?.parent })}
         />


### PR DESCRIPTION
[OP-1725](https://openimis.atlassian.net/browse/OP-1725)

Changes:

- Remove the 'none/null' option from the dropdowns menu in the form.

[OP-1725]: https://openimis.atlassian.net/browse/OP-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ