### PR TITLE
OP-1630: disable decimals

### DIFF
--- a/src/components/ProductForm/MainPanelForm.js
+++ b/src/components/ProductForm/MainPanelForm.js
@@ -115,6 +115,7 @@ const MainPanelForm = (props) => {
           readOnly={readOnly}
           value={edited?.maxMembers ?? ""}
           onChange={(maxMembers) => onEditedChanged({ ...edited, maxMembers })}
+          allowDecimals={false}
         />
       </Grid>
       <Grid item xs={3} className={classes.item}>
@@ -125,6 +126,7 @@ const MainPanelForm = (props) => {
           readOnly={readOnly}
           value={edited?.threshold ?? ""}
           onChange={(threshold) => onEditedChanged({ ...edited, threshold })}
+          allowDecimals={false}
         />
       </Grid>
       <Grid item xs={3} className={classes.item}>
@@ -136,6 +138,7 @@ const MainPanelForm = (props) => {
           readOnly={readOnly}
           value={edited?.insurancePeriod ?? ""}
           onChange={(insurancePeriod) => onEditedChanged({ ...edited, insurancePeriod })}
+          allowDecimals={false}
         />
       </Grid>
       <Grid item xs={3} className={classes.item}>
@@ -146,6 +149,7 @@ const MainPanelForm = (props) => {
           readOnly={readOnly}
           value={edited?.administrationPeriod ?? ""}
           onChange={(administrationPeriod) => onEditedChanged({ ...edited, administrationPeriod })}
+          allowDecimals={false}
         />
       </Grid>
       <Grid item xs={3} className={classes.item}>
@@ -168,7 +172,7 @@ const MainPanelForm = (props) => {
           required
           module="product"
           label="dateFrom"
-          disablePast={!!edited?.uuid}
+          disablePast={!edited?.id && !!edited?.uuid}
           readOnly={(Boolean(edited?.uuid) && !isDuplicate) || readOnly}
           onChange={(dateFrom) => onEditedChanged({ ...edited, dateFrom })}
           // NOTE: maxDate cannot be passed if endDate does not exist.

--- a/src/components/ProductForm/MainPanelForm.js
+++ b/src/components/ProductForm/MainPanelForm.js
@@ -172,7 +172,7 @@ const MainPanelForm = (props) => {
           required
           module="product"
           label="dateFrom"
-          disablePast={!edited?.id && !!edited?.uuid}
+          disablePast={!edited?.uuid}
           readOnly={(Boolean(edited?.uuid) && !isDuplicate) || readOnly}
           onChange={(dateFrom) => onEditedChanged({ ...edited, dateFrom })}
           // NOTE: maxDate cannot be passed if endDate does not exist.


### PR DESCRIPTION
[OP-1630](https://openimis.atlassian.net/browse/OP-1630)

[REQUIRED PR](https://github.com/openimis/openimis-fe-core_js/pull/191)

Changes:
- Disable decimals on maxMembers, memberTreshold, insurancePeriod, administrationPeriod fields.
- Do not show an error on dateFrom field when editing product.


[OP-1630]: https://openimis.atlassian.net/browse/OP-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ