### PR TITLE
set text beside icons

### DIFF
--- a/src/components/ProductForm/DataGrid.js
+++ b/src/components/ProductForm/DataGrid.js
@@ -6,7 +6,7 @@ import EditIcon from "@material-ui/icons/Edit";
 import DeleteIcon from "@material-ui/icons/DeleteOutlined";
 import SaveIcon from "@material-ui/icons/Save";
 import CancelIcon from "@material-ui/icons/Close";
-import { IconButton } from "@material-ui/core";
+import { IconButton, Tooltip } from "@material-ui/core";
 import _ from "lodash";
 
 const useActionsStyles = makeStyles((theme) => ({
@@ -19,9 +19,10 @@ const useActionsStyles = makeStyles((theme) => ({
 }));
 
 const CellActions = (props) => {
-  const { api, id, onRowDelete } = props;
+  const { api, id, onRowDelete, intl } = props;
   const classes = useActionsStyles();
   const isInEditMode = api.getRowMode(id) === "edit";
+  const { formatMessage } = useTranslations("product.DataGrid", intl);
 
   const handleEditClick = (event) => {
     event.stopPropagation();
@@ -50,42 +51,62 @@ const CellActions = (props) => {
   if (isInEditMode) {
     return (
       <div className={classes.root}>
-        <IconButton color="primary" size="small" aria-label="save" onClick={handleSaveClick}>
-          <SaveIcon fontSize="small" />
-        </IconButton>
-        <IconButton
-          color="inherit"
-          size="small"
-          aria-label="cancel"
-          className={classes.textPrimary}
-          onClick={handleCancelClick}
-        >
-          <CancelIcon fontSize="small" />
-        </IconButton>
+        <Tooltip title={formatMessage(intl, "core", "save")}>
+          <div>
+            <IconButton color="primary" size="small" aria-label="save" onClick={handleSaveClick}>
+              <SaveIcon fontSize="small" />
+            </IconButton>
+            {formatMessage(intl, "core", "save")}
+          </div>
+        </Tooltip>
+        <Tooltip title={formatMessage(intl, "core", "cancel")}>
+          <div>
+            <IconButton
+              color="inherit"
+              size="small"
+              aria-label="cancel"
+              className={classes.textPrimary}
+              onClick={handleCancelClick}
+            >
+              <CancelIcon fontSize="small" />
+            </IconButton>
+            {formatMessage(intl, "core", "cancel")}
+          </div>
+        </Tooltip>
       </div>
     );
   }
 
   return (
     <div className={classes.root}>
-      <IconButton
-        color="inherit"
-        className={classes.textPrimary}
-        size="small"
-        aria-label="edit"
-        onClick={handleEditClick}
-      >
-        <EditIcon fontSize="small" />
-      </IconButton>
-      <IconButton color="inherit" size="small" aria-label="delete" onClick={handleDeleteClick}>
-        <DeleteIcon fontSize="small" />
-      </IconButton>
+      <Tooltip title={formatMessage(intl, "core", "edit")}>
+        <div>
+          <IconButton
+            color="inherit"
+            className={classes.textPrimary}
+            size="small"
+            aria-label="edit"
+            onClick={handleEditClick}
+          >
+            <EditIcon fontSize="small" />
+          </IconButton>
+          {formatMessage(intl, "core", "edit")}
+        </div>
+      </Tooltip>
+      <Tooltip title={formatMessage(intl, "core", "delete")}>
+        <div>
+          <IconButton color="inherit" size="small" aria-label="delete" onClick={handleDeleteClick}>
+            <DeleteIcon fontSize="small" />
+          </IconButton>
+          {formatMessage(intl, "core", "delete")}
+        </div>
+      </Tooltip>
     </div>
   );
 };
 
 const DataGrid = (props) => {
-  const { className, onChange, error, isLoading, density, rows = [] } = props;
+  const { className, onChange, error, isLoading, density, rows = [], intl } = props;
   const [editRowsModel, setEditRowsModel] = useState({});
   const modulesManager = useModulesManager();
   const { formatMessage } = useTranslations("product.DataGrid", modulesManager);
@@ -107,7 +128,7 @@ const DataGrid = (props) => {
     onChange(rows.filter((x) => x.id !== id));
   };
 
-  const renderCellActions = (props) => <CellActions {...props} onRowDelete={onRowDelete} />;
+  const renderCellActions = (props) => <CellActions {...props} onRowDelete={onRowDelete} intl={intl} />;
 
   const columns = useMemo(
     () => [

--- a/src/components/ProductSearcher.js
+++ b/src/components/ProductSearcher.js
@@ -2,7 +2,7 @@ import React, { useState, useCallback } from "react";
 import { useProductsQuery } from "../hooks";
 import { Searcher, useTranslations, useModulesManager, ConfirmDialog } from "@openimis/fe-core";
 import ProductFilters from "./ProductFilters";
-import { Tooltip, IconButton } from "@material-ui/core";
+import { Tooltip, Button } from "@material-ui/core";
 import { Tab as TabIcon, Delete as DeleteIcon } from "@material-ui/icons";
 
 const isRowDisabled = (_, row) => Boolean(row.validityTo);
@@ -66,20 +66,20 @@ const ProductSearcher = (props) => {
 
       (p) =>
         !filters.showHistory?.value ? (
-          <>
+          <div style={{ display: 'flex', gap: '8px' }}>
             <Tooltip title={formatMessage("ProductSearcher.openNewTab")}>
-              <IconButton onClick={() => onDoubleClick(p, true)}>
-                <TabIcon />
-              </IconButton>
+              <Button startIcon={<TabIcon fontSize="small" />} onClick={() => onDoubleClick(p, true)} size="small">
+                {formatMessage("productSummaries.openNewTabButton.buttonText")}
+              </Button>
             </Tooltip>
             {canDelete(p) && (
               <Tooltip title={formatMessage("ProductSearcher.deleteProductTooltip")}>
-                <IconButton onClick={() => setProductToDelete(p)}>
-                  <DeleteIcon />
-                </IconButton>
+                <Button startIcon={<DeleteIcon fontSize="small" />} onClick={() => setProductToDelete(p)} size="small">
+                  {formatMessage("ProductSearcher.deleteProductButton.buttonText")}
+                </Button>
               </Tooltip>
             )}
-          </>
+          </div>
         ) : null,
     ];
   }, []);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -46,8 +46,10 @@
   "product.ProductFilters.showHistory": "Show Historical Values",
   "product.ProductSearcher.tableTitle": "{count} Products",
   "product.ProductSearcher.deleteProductTooltip": "Delete product",
+  "product.ProductSearcher.deleteProductButton.buttonText": "Delete",
+  "productSummaries.openNewTabButton.buttonText": "Open",
   "product.ProductSearcher.openNewTab": "Open in new tab",
-
+  "product.ProductSearcher.openNewTabButton.buttonText": "Open",
   "product.ProductForm.title": "Product {label}",
   "product.ProductForm.emptyTitle": "New Product",
   "product.FormMainPanel.validitySectionTitle": "Validity",


### PR DESCRIPTION
Added descriptive text next to icon-only buttons to improve usability and accessibility.
According to [WCAG 2.1](https://www.w3.org/TR/WCAG21/) and usability best practices, relying on icons alone can create confusion since many icons do not have a universal meaning. By adding short descriptive labels, the interface becomes more intuitive, accessible to all users, and compliant with accessibility standards.