### PR TITLE
set text beside icons OP-2578

### DIFF
--- a/src/components/ProductSearcher.js
+++ b/src/components/ProductSearcher.js
@@ -85,22 +85,22 @@ const ProductSearcher = (props) => {
         !filters.showHistory?.value ? (
           <div className={classes.horizontalButtonContainer}>
             <Tooltip title={formatMessage("ProductSearcher.openNewTab")}>
-              <IconButton onClick={() => onDoubleClick(p, true)}>
-                <TabIcon />
-              </IconButton>
+              <Button startIcon={<TabIcon />} onClick={() => onDoubleClick(p, true)}>
+                {formatMessage("ProductSearcher.openNewTabButton")}
+              </Button>
             </Tooltip>
             {canDuplicate(p) && (
               <Tooltip title={formatMessage("ProductSearcher.duplicateProductTooltip")}>
-                <IconButton onClick={() => onDuplicate(p, true)}>
-                  <FileCopyIcon />
-                </IconButton>
+                <Button startIcon={<FileCopyIcon />} onClick={() => onDuplicate(p, true)}>
+                  {formatMessage("ProductSearcher.duplicateProductButton")}
+                </Button>
               </Tooltip>
             )}
             {canDelete(p) && (
               <Tooltip title={formatMessage("ProductSearcher.deleteProductTooltip")}>
-                <IconButton onClick={() => setProductToDelete(p)}>
-                  <DeleteIcon />
-                </IconButton>
+                <Button startIcon={<DeleteIcon />} onClick={() => setProductToDelete(p)}>
+                  {formatMessage("ProductSearcher.deleteProductButton")}
+                </Button>
               </Tooltip>
             )}
           </div>

--- a/src/components/ProductSearcher.js
+++ b/src/components/ProductSearcher.js
@@ -3,7 +3,7 @@ import { useProductsQuery } from "../hooks";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { Searcher, useTranslations, combine, useModulesManager, ConfirmDialog } from "@openimis/fe-core";
 import ProductFilters from "./ProductFilters";
-import { Tooltip, IconButton } from "@material-ui/core";
+import { Tooltip, Button } from "@material-ui/core";
 import { Tab as TabIcon, Delete as DeleteIcon } from "@material-ui/icons";
 import FileCopyIcon from '@material-ui/icons/FileCopy';
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,4 +1,7 @@
 {
+  "product.ProductSearcher.deleteProductButton": "Delete",
+  "product.ProductSearcher.duplicateProductButton": "Duplicate",
+  "product.ProductSearcher.openNewTabButton": "Open",
   "product.Product": "Product",
   "product.ProductPicker.placeholder": "Search Product…",
   "product.ProductPicker.aboveLimit": "Over {limit} products found. For specific results, please use the search bar.",


### PR DESCRIPTION
Added descriptive text next to icon-only buttons to improve usability and accessibility.
According to [WCAG 2.1](https://www.w3.org/TR/WCAG21/) and usability best practices, relying on icons alone can create confusion since many icons do not have a universal meaning. By adding short descriptive labels, the interface becomes more intuitive, accessible to all users, and compliant with accessibility standards.