### PR TITLE
Fix fetchProducts

### DIFF
--- a/src/components/ProductSearcher.jsx
+++ b/src/components/ProductSearcher.jsx
@@ -20,7 +20,7 @@ const ProductSearcher = (props) => {
   const { formatMessage, formatDateFromISO, formatMessageWithValues } = useTranslations("product", modulesManager);
   const [filters, setFilters] = useState({});
   const [productToDelete, setProductToDelete] = useState(null);
-  const { data, isLoading, error, refetch } = useProductsQuery({ filters }, { skip: true, keepStale: true });
+  const { data, isLoading, error, refetch } = useProductsQuery({ filters }, { keepStale: true });
   const filtersToQueryParam = useCallback((state) => {
     let params = {};
     if (!state.beforeCursor && !state.afterCursor) {


### PR DESCRIPTION
# Description

On https://vite.s1.openimis.org/front/admin/products We observe that the product list is empty, even though there are products in the database. This is due to the parameter "skip = true" which is passed to useProductsQuery.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1856" height="995" alt="Capture d’écran du 2026-04-09 19-28-55" src="https://github.com/user-attachments/assets/a41c0b71-3835-48d0-899f-343924f0a30c" />
<img width="1856" height="995" alt="Capture d’écran du 2026-04-09 19-30-46" src="https://github.com/user-attachments/assets/c6de4749-293f-4e3f-bf83-702818cd6109" />

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
