### PR TITLE
prevent the backend error product_code length > 8 OP-2494

### DIFF
--- a/src/components/ProductForm/MainPanelForm.js
+++ b/src/components/ProductForm/MainPanelForm.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { connect, useDispatch } from "react-redux";
 
 import { Grid } from "@material-ui/core";
@@ -22,6 +22,7 @@ import {
   productCodeValidationClear,
 } from "../../actions";
 import SectionTitle from "../SectionTitle";
+import { PRODUCT_CODE_MAX_LENGTH } from "../../constants"
 
 const styles = (theme) => ({
   item: theme.paper.item,
@@ -43,6 +44,7 @@ const MainPanelForm = (props) => {
   const dispatch = useDispatch();
   const modulesManager = useModulesManager();
   const { formatMessage } = useTranslations("product.FormMainPanel", modulesManager);
+  const [codeLengthError, setCodeLengthError] = useState(null);
 
   useEffect(() => {
     if (edited?.id) dispatch(fetchProduct(modulesManager, { "productId": edited.id }));
@@ -55,6 +57,15 @@ const MainPanelForm = (props) => {
     return true;
   };
 
+  const handleCodeChange = (code) => {
+    onEditedChanged({ ...edited, code });
+    if (code && code.length > PRODUCT_CODE_MAX_LENGTH) {
+      setCodeLengthError("product.codeTooLong");
+    } else {
+      setCodeLengthError(null);
+    }
+  };
+
   return (
     <Grid container direction="row">
       <Grid item xs={3} className={classes.item}>
@@ -65,14 +76,14 @@ const MainPanelForm = (props) => {
           clearAction={productCodeValidationClear}
           setValidAction={productCodeSetValid}
           shouldValidate={shouldValidate}
-          codeTakenLabel="product.alreadyTaken"
+          codeTakenLabel={codeLengthError ? "product.codeTooLong" : "product.alreadyTaken"}
           readOnly={readOnly}
           isValid={isProductCodeValid}
           isValidating={isProductCodeValidating}
-          validationError={productCodeValidationError}
+          validationError={codeLengthError || productCodeValidationError}
           label="product.code"
           module="product"
-          onChange={(code) => onEditedChanged({ ...edited, code })}
+          onChange={handleCodeChange}
           required={true}
           value={edited?.code ?? ""}
         />

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,8 @@ export const RIGHT_PRODUCT_DUPLICATE = 121005;
 export const EMPTY_STRING = '';
 export const DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 
+export const PRODUCT_CODE_MAX_LENGTH = 8;
+
 export const PRODUCT_QUANTITY_LIMIT = 15;
 
 export const PRICE_ORIGINS = { P: "PRICELIST", O: "PROVIDER", R: "RELATIVE" };

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8,6 +8,7 @@
   "product.Product.none": "None",
   "product.name": "Name",
   "product.code": "Code",
+  "product.codeTooLong": "Product code must not exceed 8 characters",
   "product.region": "Region",
   "product.dateFrom": "Date From",
   "product.dateTo": "Date To",

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,12 +35,22 @@ export const validateProductForm = (values, rules, isProductCodeValid) => {
     errors.dateTo = true;
   }
 
+  if (values.dateTo) {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const dateTo = new Date(values.dateTo);
+    dateTo.setHours(0, 0, 0, 0);
+    if (dateTo < today) {
+      errors.dateTo = true;
+    }
+  }
+
   if (values.ageMaximal < values.ageMinimal){
     errors.ageMaximal = true;
     errors.ageMinimal = true;
   }
 
-  if (!isProductCodeValid) {
+  if (!isProductCodeValid || values?.code?.length > 8) {
     errors.isProductCodeInvalid = true;
   }
 


### PR DESCRIPTION
#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

This PR is set up to prevents Django error product_code length > 8 characters by checking the length in javascript side before submitting the form.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [x] External reference (e.g., Jira):  https://openimis.atlassian.net/browse/OP-2494 

## Demo

<img width="825" height="485" alt="image" src="https://github.com/user-attachments/assets/1510e9dd-ebd5-440a-8a17-c493f9ff88a8" />

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
