### PR TITLE
prevent the backend error product_code length > 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,6 @@ None (Administration module providing menu entries to proxied pages for products
 - `product.ProductPicker`: Picker that returns products matching the string entered by the user.
 - `product.hooks.useProductsQuery`: Hook to get a filtered connection on products
 - `product.hooks.useProductQuery`: Hook to get a product with all its fields
+
+## Configurations Options
+- `productCodeMaxLength`: Maximum length of the product code (default: 8)

--- a/src/components/ProductForm/MainPanelForm.jsx
+++ b/src/components/ProductForm/MainPanelForm.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { connect, useDispatch } from "react-redux";
 
 import { Grid } from "@mui/material";
@@ -22,6 +22,7 @@ import {
   productCodeValidationClear,
 } from "../../actions";
 import SectionTitle from "../SectionTitle";
+import { PRODUCT_CODE_MAX_LENGTH } from "../../constants";
 
 const StyledItem = styled('div')(({ theme }) => ({
   ...theme.paper?.item ?? {},
@@ -42,6 +43,7 @@ const MainPanelForm = (props) => {
   const dispatch = useDispatch();
   const modulesManager = useModulesManager();
   const { formatMessage } = useTranslations("product.FormMainPanel", modulesManager);
+  const [codeLengthError, setCodeLengthError] = useState(null);
 
   useEffect(() => {
     if (edited?.id) dispatch(fetchProduct(modulesManager, { "productId": edited.id }));
@@ -52,6 +54,16 @@ const MainPanelForm = (props) => {
     const { savedProductCode } = props;
     if ((!!edited.id && inputValue === savedProductCode) || (!savedProductCode && !!edited.id)) return false;
     return true;
+  };
+  const productCodeMaxLength = modulesManager.getConf("fe-product", "productCodeMaxLength", PRODUCT_CODE_MAX_LENGTH);
+
+  const handleCodeChange = (code) => {
+    onEditedChanged({ ...edited, code });
+    if (code && code.length > productCodeMaxLength) {
+      setCodeLengthError("product.codeTooLong");
+    } else {
+      setCodeLengthError(null);
+    }
   };
 
   return (
@@ -64,14 +76,14 @@ const MainPanelForm = (props) => {
           clearAction={productCodeValidationClear}
           setValidAction={productCodeSetValid}
           shouldValidate={shouldValidate}
-          codeTakenLabel="product.alreadyTaken"
+          codeTakenLabel={codeLengthError || "product.alreadyTaken"}
           readOnly={readOnly}
           isValid={isProductCodeValid}
           isValidating={isProductCodeValidating}
-          validationError={productCodeValidationError}
+          validationError={codeLengthError || productCodeValidationError}
           label="product.code"
           module="product"
-          onChange={(code) => onEditedChanged({ ...edited, code })}
+          onChange={handleCodeChange}
           required={true}
           value={edited?.code ?? ""}
         />

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,8 @@ export const RIGHT_PRODUCT_DUPLICATE = 121005;
 export const EMPTY_STRING = '';
 export const DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 
+export const PRODUCT_CODE_MAX_LENGTH = 8;
+
 export const PRODUCT_QUANTITY_LIMIT = 15;
 
 export const PRICE_ORIGINS = { P: "PRICELIST", O: "PROVIDER", R: "RELATIVE" };

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8,6 +8,7 @@
   "product.Product.none": "None",
   "product.name": "Name",
   "product.code": "Code",
+  "product.codeTooLong": "Product code must not exceed 8 characters",
   "product.region": "Region",
   "product.dateFrom": "Date From",
   "product.dateTo": "Date To",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 import { graphqlWithVariables, toISODate } from "@openimis/fe-core";
 import _ from "lodash";
-import { EMPTY_STRING, LIMIT_COLUMNS, LIMIT_TYPES, PRICE_ORIGINS } from "./constants";
+import { EMPTY_STRING, LIMIT_COLUMNS, LIMIT_TYPES, PRICE_ORIGINS, PRODUCT_CODE_MAX_LENGTH } from "./constants";
 
 export const validateProductForm = (values, rules, isProductCodeValid) => {
   values = { ...values };
@@ -40,7 +40,7 @@ export const validateProductForm = (values, rules, isProductCodeValid) => {
     errors.ageMinimal = true;
   }
 
-  if (!isProductCodeValid) {
+  if (!isProductCodeValid || (values?.code && values?.code?.length > PRODUCT_CODE_MAX_LENGTH)) {
     errors.isProductCodeInvalid = true;
   }
 


### PR DESCRIPTION
#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

This PR is set up to prevents Django error product_code length > 8 characters by checking the length in javascript side before submitting the form.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [x] External reference (e.g., Jira):  https://openimis.atlassian.net/browse/OP-2494 

## Demo

<img width="575" height="476" alt="image" src="https://github.com/user-attachments/assets/050efc94-bf2b-4e9e-8785-32845b9b3fef" />

## Checklist
- [ ] Unit tests added/modified
- [x] I18n / translation handled