### PR TITLE
disable save when validityTo < currentDate

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -35,6 +35,16 @@ export const validateProductForm = (values, rules, isProductCodeValid) => {
     errors.dateTo = true;
   }
 
+  if (values.dateTo) {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const dateTo = new Date(values.dateTo);
+    dateTo.setHours(0, 0, 0, 0);
+    if (dateTo < today) {
+      errors.dateTo = true;
+    }
+  }
+
   if (values.ageMaximal < values.ageMinimal){
     errors.ageMaximal = true;
     errors.ageMinimal = true;


### PR DESCRIPTION
#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

When a product form is opened, if the validity date is prior to today's date, the validityto_date field displays an error message as shown in the screenshot. However, the save button remains active. Therefore, we assume that it is not normal to modify an already expired product to disable the save button in this case.

# Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [x] Enhancement

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1844" height="1026" alt="Capture d’écran du 2026-06-04 12-04-10" src="https://github.com/user-attachments/assets/3a912f67-e1ee-4a06-8d1b-e6a66b232827" />
<img width="1844" height="1026" alt="Capture d’écran du 2026-06-04 12-04-19" src="https://github.com/user-attachments/assets/2f83ecaf-d972-4ee7-ba35-a60c946b7e4e" />

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
