### PR TITLE
hide actions buttons in searcher

### DIFF
--- a/src/components/ProductSearcher.jsx
+++ b/src/components/ProductSearcher.jsx
@@ -3,7 +3,6 @@ import { useProductsQuery } from "../hooks";
 import { styled } from "@mui/material/styles";
 import { Searcher, useTranslations, combine, useModulesManager, ConfirmDialog } from "@openimis/fe-core";
 import ProductFilters from "./ProductFilters";
-import { Tooltip, Button } from "@mui/material";
 import { GetIconComponent, ActionMenu } from "@openimis/fe-core";
 const TabIcon = GetIconComponent("Tab")
 const DeleteIcon = GetIconComponent("Delete")

--- a/src/components/ProductSearcher.jsx
+++ b/src/components/ProductSearcher.jsx
@@ -4,7 +4,7 @@ import { styled } from "@mui/material/styles";
 import { Searcher, useTranslations, combine, useModulesManager, ConfirmDialog } from "@openimis/fe-core";
 import ProductFilters from "./ProductFilters";
 import { Tooltip, Button } from "@mui/material";
-import { GetIconComponent } from "@openimis/fe-core";
+import { GetIconComponent, ActionMenu } from "@openimis/fe-core";
 const TabIcon = GetIconComponent("Tab")
 const DeleteIcon = GetIconComponent("Delete")
 
@@ -87,25 +87,29 @@ const ProductSearcher = (props) => {
       (p) =>
         !filters.showHistory?.value ? (
           <StyledHorizontalButtonContainer>
-            <Tooltip title={formatMessage("ProductSearcher.openNewTab")}>
-              <Button startIcon={<TabIcon />} onClick={() => onDoubleClick(p, true)}>
-                {formatMessage("ProductSearcher.openNewTabButton")}
-              </Button>
-            </Tooltip>
-            {canDuplicate(p) && (
-              <Tooltip title={formatMessage("ProductSearcher.duplicateProductTooltip")}>
-                <Button startIcon={<FileCopyIcon />} onClick={() => onDuplicate(p, true)}>
-                  {formatMessage("ProductSearcher.duplicateProductButton")}
-                </Button>
-              </Tooltip>
-            )}
-            {canDelete(p) && (
-              <Tooltip title={formatMessage("ProductSearcher.deleteProductTooltip")}>
-                <Button startIcon={<DeleteIcon />} onClick={() => setProductToDelete(p)}>
-                  {formatMessage("ProductSearcher.deleteProductButton")}
-                </Button>
-              </Tooltip>
-            )}
+            <ActionMenu
+              actions={[
+                {
+                  icon: <TabIcon fontSize="small"/>,
+                  label: formatMessage("ProductSearcher.openNewTabButton"),
+                  onClick: () => onDoubleClick(p, true),
+                  tooltip: formatMessage("ProductSearcher.openNewTab")
+                },
+                canDuplicate(p) && {
+                  icon: <FileCopyIcon fontSize="small"/>,
+                  label: formatMessage("ProductSearcher.duplicateProductButton"),
+                  onClick: () => onDuplicate(p, true),
+                  tooltip: formatMessage("ProductSearcher.duplicateProductTooltip")
+                },
+                canDelete(p) && {
+                  divider: true,
+                  icon: <DeleteIcon fontSize="small"/>,
+                  label: formatMessage("ProductSearcher.deleteProductButton"),
+                  onClick: () => setProductToDelete(p),
+                  tooltip: formatMessage("ProductSearcher.deleteProductTooltip")
+                }
+              ]}
+          />
           </StyledHorizontalButtonContainer>
         ) : null,
     ];

--- a/src/components/ProductSearcher.jsx
+++ b/src/components/ProductSearcher.jsx
@@ -1,9 +1,16 @@
 import React, { useState, useCallback } from "react";
 import { useProductsQuery } from "../hooks";
 import { styled } from "@mui/material/styles";
-import { Searcher, useTranslations, combine, useModulesManager, ConfirmDialog } from "@openimis/fe-core";
+import { 
+  Searcher, 
+  useTranslations, 
+  combine, 
+  useModulesManager, 
+  ConfirmDialog, 
+  GetIconComponent, 
+  ActionMenu 
+} from "@openimis/fe-core";
 import ProductFilters from "./ProductFilters";
-import { GetIconComponent, ActionMenu } from "@openimis/fe-core";
 const TabIcon = GetIconComponent("Tab")
 const DeleteIcon = GetIconComponent("Delete")
 

--- a/src/components/ProductSearcher.jsx
+++ b/src/components/ProductSearcher.jsx
@@ -114,7 +114,7 @@ const ProductSearcher = (props) => {
                   onClick: () => setProductToDelete(p),
                   tooltip: formatMessage("ProductSearcher.deleteProductTooltip")
                 }
-              ]}
+              ].filter(Boolean)}
           />
           </StyledHorizontalButtonContainer>
         ) : null,


### PR DESCRIPTION
# Description

Hide the action buttons in the list to free up space and improve the table layout

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [x] Requires [https://github.com/openimis/openimis-fe-core_js/pull/342], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1430" height="372" alt="Screenshot 2026-07-31 at 4 01 33 PM" src="https://github.com/user-attachments/assets/86968038-4f94-46a4-b5a2-11ee04017308" />


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
