### PR TITLE
fix(product): OP-3119 Fix unsafe null dereferences in TabsForm and Pr…

### DIFF
--- a/src/components/ProductForm/TabsForm.jsx
+++ b/src/components/ProductForm/TabsForm.jsx
@@ -50,13 +50,16 @@ const TabsForm = (props) => {
 
   useEffect(() => {
     if (!isLoadingLimitDefaults && !isLoadedLimitDefaults) {
-      setPriceOrigin(dataLimitDefaults.limitDefaults.priceOrigin?? 'P')
-      setLimitType(dataLimitDefaults.limitDefaults.limitType?? 'C')
-      setCoInsuranceDefaultValue(dataLimitDefaults.limitDefaults.defaultLimitCoInsuranceValue?? 100)
-      setFixedDefaultValue(dataLimitDefaults.limitDefaults.defaultLimitFixedValue?? 0)
-      setLoadedLimitDefaults(true)
+      const limitDefaults = dataLimitDefaults?.limitDefaults;
+      if (limitDefaults) {
+        setPriceOrigin(limitDefaults.priceOrigin ?? 'P');
+        setLimitType(limitDefaults.limitType ?? 'C');
+        setCoInsuranceDefaultValue(limitDefaults.defaultLimitCoInsuranceValue ?? 100);
+        setFixedDefaultValue(limitDefaults.defaultLimitFixedValue ?? 0);
+      }
+      setLoadedLimitDefaults(true);
     }
-  }, [dataLimitDefaults, isLoadingLimitDefaults]);
+  }, [dataLimitDefaults, isLoadingLimitDefaults, isLoadedLimitDefaults]);
 
   const getLimitValueSwitch = (limitType) => {
       if (limitType === 'F' || limitType === LIMIT_TYPES.F) {

--- a/src/pages/ProductDetailsPage.jsx
+++ b/src/pages/ProductDetailsPage.jsx
@@ -74,7 +74,7 @@ const ProductDetailsPage = (props) => {
       setLoaded(true);
     }
     if (!isLoadingRules) {
-      setValuesRules(rulesToFormValues(dataRules.pageDisplayRules ?? {}));
+      setValuesRules(rulesToFormValues(dataRules?.pageDisplayRules ?? {}));
       setLoadedRules(true);
     }
   }, [data, isLoading, dataRules, isLoadingRules]);

--- a/src/utils.js
+++ b/src/utils.js
@@ -100,11 +100,11 @@ export const toFormValues = (product, shouldDuplicate) => {
   };
 };
 
-export const rulesToFormValues = (rules) => {
+export const rulesToFormValues = (rules = {}) => {
   return {
     ...rules,
-    minLimitValue: Number(rules.minLimitValue) ?? 0.0,
-    maxLimitValue: Number(rules.maxLimitValue) ?? 100.0,
+    minLimitValue: rules?.minLimitValue != null ? Number(rules.minLimitValue) : 0.0,
+    maxLimitValue: rules?.maxLimitValue != null ? Number(rules.maxLimitValue) : 100.0,
   };
 };
 


### PR DESCRIPTION
…oductDetailsPage when queries are loading or skipped

#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

# Fix Unsafe Query Result Access in Product Module

## Summary

Fixes unhandled `TypeError` exceptions caused by unsafe access to GraphQL query results in `TabsForm.jsx`, `ProductDetailsPage.jsx`, and `utils.js`.

The errors occurred when GraphQL queries were skipped or were still loading, causing query result objects such as `dataLimitDefaults` and `dataRules` to be `null` or `undefined`.

## Issues Solved

### 1. Unsafe `dataLimitDefaults` Access in `TabsForm.jsx`

**Problem**

`TabsForm.jsx` directly accessed:


dataLimitDefaults.limitDefaults.priceOrigin
# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
